### PR TITLE
Fix loadAndRun onLoad and continued streaming

### DIFF
--- a/src/main/scala/uk/sky/fs2/kafka/topicloader/TopicLoader.scala
+++ b/src/main/scala/uk/sky/fs2/kafka/topicloader/TopicLoader.scala
@@ -34,6 +34,16 @@ trait TopicLoader {
 
   import TopicLoader.{*, given}
 
+  /** Stream that loads the specified topics from the beginning and completes when the offsets reach the point specified
+    * by the requested strategy.
+    *
+    * @param topics
+    *   topics to load
+    * @param strategy
+    *   A [[LoadTopicStrategy]]
+    * @param consumerSettings
+    *   [[fs2.kafka.ConsumerSettings]] for the given topics
+    */
   def load[F[_] : Async : LoggerFactory, K, V](
       topics: NonEmptyList[String],
       strategy: LoadTopicStrategy,
@@ -44,6 +54,16 @@ trait TopicLoader {
       .evalMap(consumer => OptionT(loadIfNonEmpty(topics, strategy, consumer)).getOrElse(Stream.empty))
       .flatten
 
+  /** Stream that loads the specified topics from the beginning. When the latest current offsets are reached, the
+    * `onLoad` callback is evaluated, and the stream continues.
+    *
+    * @param topics
+    *   topics to load
+    * @param consumerSettings
+    *   [[fs2.kafka.ConsumerSettings]] for the given topics
+    * @param onLoad
+    *   A callback that will be evaluated on once the current offsets are reached
+    */
   def loadAndRun[F[_] : Async : LoggerFactory, K, V](
       topics: NonEmptyList[String],
       consumerSettings: ConsumerSettings[F, K, V]

--- a/src/test/scala/integration/TopicLoaderIntSpec.scala
+++ b/src/test/scala/integration/TopicLoaderIntSpec.scala
@@ -215,7 +215,7 @@ class TopicLoaderIntSpec extends KafkaSpecBase[IO] {
     "execute callback if the topic is empty and keep streaming" in withKafkaContext { ctx =>
       import ctx.given
 
-      val (preLoad, postLoad) = records(1 to 15).splitAt(10)
+      val postLoad = records(1 to 15)
 
       for {
         loadState  <- Ref.of[IO, Boolean](false)
@@ -226,11 +226,11 @@ class TopicLoaderIntSpec extends KafkaSpecBase[IO] {
                         r => topicState.getAndUpdate(_ :+ r).void
                       ).surround {
                         for {
-                          _         <- loadState.get.asserting(_ shouldBe true)
+                          _         <- eventually(loadState.get.asserting(_ shouldBe true))
                           _         <- publishStringMessages(testTopic1, postLoad)
                           assertion <-
                             eventually(
-                              topicState.get.asserting(_ should contain theSameElementsAs (preLoad ++ postLoad))
+                              topicState.get.asserting(_ should contain theSameElementsAs postLoad)
                             )
                         } yield assertion
                       }

--- a/src/test/scala/integration/TopicLoaderIntSpec.scala
+++ b/src/test/scala/integration/TopicLoaderIntSpec.scala
@@ -190,7 +190,10 @@ class TopicLoaderIntSpec extends KafkaSpecBase[IO] {
 
       val (preLoad, postLoad) = records(1 to 15).splitAt(10)
 
-      def testState(loadState: Ref[IO, Boolean], topicState: Ref[IO, Seq[(String, String)]]): IO[Assertion] =
+      def assertPostLoadRecordsConsumed(
+          loadState: Ref[IO, Boolean],
+          topicState: Ref[IO, Seq[(String, String)]]
+      ): IO[Assertion] =
         loadAndRunR(NonEmptyList.one(testTopic1))(
           _ => loadState.set(true),
           r => topicState.getAndUpdate(_ :+ r).void
@@ -211,7 +214,7 @@ class TopicLoaderIntSpec extends KafkaSpecBase[IO] {
         topicState <- Ref.empty[IO, Seq[(String, String)]]
         _          <- createCustomTopics(NonEmptyList.one(testTopic1))
         _          <- publishStringMessages(testTopic1, preLoad)
-        assertion  <- testState(loadState, topicState)
+        assertion  <- assertPostLoadRecordsConsumed(loadState, topicState)
       } yield assertion
     }
 
@@ -220,7 +223,10 @@ class TopicLoaderIntSpec extends KafkaSpecBase[IO] {
 
       val postLoad = records(1 to 15)
 
-      def testState(loadState: Ref[IO, Boolean], topicState: Ref[IO, Seq[(String, String)]]): IO[Assertion] =
+      def assertPostLoadRecordsConsumed(
+          loadState: Ref[IO, Boolean],
+          topicState: Ref[IO, Seq[(String, String)]]
+      ): IO[Assertion] =
         loadAndRunR(NonEmptyList.one(testTopic1))(
           _ => loadState.set(true),
           r => topicState.getAndUpdate(_ :+ r).void
@@ -239,7 +245,7 @@ class TopicLoaderIntSpec extends KafkaSpecBase[IO] {
         loadState  <- Ref.of[IO, Boolean](false)
         topicState <- Ref.empty[IO, Seq[(String, String)]]
         _          <- createCustomTopics(NonEmptyList.one(testTopic1))
-        assertion  <- testState(loadState, topicState)
+        assertion  <- assertPostLoadRecordsConsumed(loadState, topicState)
       } yield assertion
     }
 
@@ -249,7 +255,10 @@ class TopicLoaderIntSpec extends KafkaSpecBase[IO] {
       val (forTopic1, forTopic2) = records(1 to 15).splitAt(10)
       val topics                 = NonEmptyList.of(testTopic1, testTopic2)
 
-      def testState(loadState: Ref[IO, Boolean], topicState: Ref[IO, Seq[(String, String)]]): IO[Assertion] =
+      def assertPostLoadRecordsConsumed(
+          loadState: Ref[IO, Boolean],
+          topicState: Ref[IO, Seq[(String, String)]]
+      ): IO[Assertion] =
         loadAndRunR(topics)(
           _ => loadState.set(true),
           r => topicState.getAndUpdate(_ :+ r).void
@@ -270,7 +279,7 @@ class TopicLoaderIntSpec extends KafkaSpecBase[IO] {
         topicState <- Ref.empty[IO, Seq[(String, String)]]
         _          <- createCustomTopics(topics)
         _          <- publishStringMessages(testTopic1, forTopic1)
-        assertion  <- testState(loadState, topicState)
+        assertion  <- assertPostLoadRecordsConsumed(loadState, topicState)
       } yield assertion
     }
 


### PR DESCRIPTION
## Description

Fixes a bug where loadAndRun semantics fail for empty topics. Also copied over the relevant documentation from https://github.com/sky-uk/kafka-topic-loader/blob/master/src/main/scala/uk/sky/kafka/topicloader/TopicLoader.scala#L70

## Related Issues

- Fixes #44

## Definition of Done:

The Below tasks should be completed before marking a PR as ready for review.

- [x] Added / Removed / Updated relevant tests
- [x] Scaladoc updated
