### PR TITLE
Remove unchunking evalScan and apply logging to chunks for performance

### DIFF
--- a/src/main/scala/uk/sky/fs2/kafka/topicloader/TopicLoader.scala
+++ b/src/main/scala/uk/sky/fs2/kafka/topicloader/TopicLoader.scala
@@ -113,14 +113,14 @@ trait TopicLoader {
 
     Stream.eval {
       emptyOffsets.toList.traverse { (tp, o) =>
-        logger.warn(s"Not loading data from empty ${tp.show} at offset ${o.highest}")
+        logger.info(s"Not loading data from empty ${tp.show} at offset ${o.highest}")
       }
     } >>
       stream
         .scan(allHighestOffsets)(emitRecordRemovingConsumedPartition[K, V])
         .takeWhile(_.partitionOffsets.nonEmpty, takeFailure = true)
         .evalTapChunk(_.partitionLastOffset.traverse { last =>
-          logger.warn(s"Finished loading data from ${last.topicPartition.show} at offset ${last.offset}")
+          logger.info(s"Finished loading data from ${last.topicPartition.show} at offset ${last.offset}")
         })
         .collect { case WithRecord(r) => r }
   }


### PR DESCRIPTION
## Description

Currently we use `evalScan` to perform the logic of producing a ConsumerRecord and the non-empty partition map. this is effectful as we perform logging upon reaching the highest offset.

It would be more efficient to use the non-effectful scan, as `evalScan` de-chunks a stream into singleton chunks. There unfortunately is no `evalScanChunks` equivalent of `scanChunks`.

We still perform the logging, however we can operate on the chunk for performance by using `evalTapChunk`

## Related Issues

- Connects to #60 

## Definition of Done:

The Below tasks should be completed before marking a PR as ready for review.

- [ ] Added / Removed / Updated relevant tests
- [ ] Scaladoc updated
